### PR TITLE
Fixed too many registry (consul) requests

### DIFF
--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -106,6 +106,7 @@ func (c *Grpc) Call(
 		return err
 	}
 
+	// Put the connection back or close connection
 	defer pcc.Close()
 
 	cc, ok := pcc.Conn().(*grpc.ClientConn)

--- a/pool/default.go
+++ b/pool/default.go
@@ -198,7 +198,6 @@ type ClientConn struct {
 	conn    FactoryConn
 	address string
 	p       *ConnectionPool
-	sync.RWMutex
 }
 
 // Address returns the factory connection address
@@ -213,12 +212,5 @@ func (cc *ClientConn) Conn() FactoryConn {
 
 // Close - closes the connection to the gRPC service server
 func (cc *ClientConn) Close() error {
-	cc.RLock()
-	defer cc.RUnlock()
-
-	if cc.conn != nil {
-		return cc.p.CloseFunc(cc.conn)
-	}
-
 	return cc.p.add(cc.address, cc.conn)
 }


### PR DESCRIPTION
Mistake in the code was closing all connections instead of putting it back in the pool when the pool was not full, causing too many requests to registry leading to errors.